### PR TITLE
改进 macOS 下的部分打包流程

### DIFF
--- a/ElectronJS/package_macos.sh
+++ b/ElectronJS/package_macos.sh
@@ -8,6 +8,11 @@ rm -rf out
 rm -r ../.temp_to_pub/EasySpider_MacOS/EasySpider.app
 npm run make
 unzip out/make/zip/darwin/*64/EasySpider-darwin* -d ../.temp_to_pub/EasySpider_MacOS/
+# 使用 adhoc 签名
+# 这样程序在 macOS 就会显示为“无法验证开发者，你应将其移动到废纸篓”而不是“此应用已损坏，无法打开”了。
+# 这样软件就可以直接在设置-隐私与安全性中批准打开，而不需要 `xattr -d` 强行清除属性
+# 这不是一个真正的签名，只是一个空签名，不能让软件通过门禁认证。
+codesign --force --deep --sign - ../.temp_to_pub/EasySpider_MacOS/EasySpider.app
 # mv out/EasySpider-darwin-*64/EasySpider.app ../.temp_to_pub/EasySpider_MacOS/
 rm ../.temp_to_pub/EasySpider_MacOS/EasySpider.app/Contents/Resources/app/VS_BuildTools.exe
 rm -r ../.temp_to_pub/EasySpider_MacOS/EasySpider.app/Contents/Resources/app/chrome_win64

--- a/ElectronJS/update_chrome.py
+++ b/ElectronJS/update_chrome.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
         finally:
             shutil.rmtree("./chromedrivers")
         os.chmod("./chromedriver_mac64", 0o755)
-        os.chmod("./chrome_mac64.app", 0o555)
-        os.chmod("./chrome_mac64.app/Contents/MacOS/Google Chrome", 0o555)
+        os.chmod("./chrome_mac64.app", 0o755)
+        os.chmod("./chrome_mac64.app/Contents/MacOS/Google Chrome", 0o755)
 
     print("Done and don't forget to generate executestage EXEcutable program!")

--- a/ElectronJS/update_chrome.py
+++ b/ElectronJS/update_chrome.py
@@ -59,6 +59,15 @@ def get_chrome_version():
             return version_re.findall(_v)[0][:3]
         except WindowsError as e:
             print("check Chrome failed:{}".format(e))
+    elif sys.platform == 'darwin':
+        # 通过读取 /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/Current 这一符号连接指向的文件夹的名称，获得 Chrome 版本号
+        try:
+            full_version = os.path.basename(os.path.abspath(os.readlink("/Applications/Google Chrome.app/Contents/Frameworks/Google "
+                                                                "Chrome Framework.framework/Versions/Current")))
+            return full_version.split(".")[0]
+        # 如果找不到 Chrome 程序或者获取错误，回退到默认的 131 版本
+        except (OSError, IndexError):
+            return version
     else:
         return version
 
@@ -90,25 +99,31 @@ old_driver_version = {
 }
 
 if __name__ == "__main__":
-    os.system("npm install -g extract-stealth-evasions") # 安装stealth.min.js
-    os.system("npx extract-stealth-evasions") # 提取stealth.min.js
+    #os.system("npm install -g extract-stealth-evasions") # 安装stealth.min.js
+    #os.system("npx extract-stealth-evasions") # 提取stealth.min.js
+
+    # chromedriver 在 chrome 114 版本之后，提供了一个新的 API 来获取已知的 Chrome 版本和下载链接
+    # 之前的版本需要手动维护下载链接
+    # 现在可以通过访问 https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
+    # 来获取最新的 Chrome 版本和下载链接
     driver_downloads = []
-    response = requests.get(chrome_driver_url)
-    if response.status_code == 200:
-        versions = json.loads(response.content)["versions"]
-        versions = versions[::-1] # 倒序排列数组
-        for info in versions:
-            version = info["version"].split(".")[0]
-            if version.find(chrome_version) == 0:
-                downloads = info["downloads"]
-                if "chromedriver" in downloads:
-                    print(info["version"])
-                    driver_downloads = downloads["chromedriver"]
-                    break
+    if int(chrome_version.split(".")[0]) >= 114:
+        response = requests.get(chrome_driver_url)
+        if response.status_code == 200:
+            versions = json.loads(response.content)["versions"]
+            versions = versions[::-1] # 倒序排列数组
+            for info in versions:
+                version = info["version"].split(".")[0]
+                if version.find(chrome_version) == 0:
+                    downloads = info["downloads"]
+                    if "chromedriver" in downloads:
+                        print(info["version"])
+                        driver_downloads = downloads["chromedriver"]
+                        break
+        else:
+            print("Error: ", response.status_code)
+            exit(1)
     else:
-        print("Error: " + response.status_code)
-        exit(1)
-    if not driver_downloads and int(chrome_version) < 115:
         if chrome_version not in old_driver_version:
             print("没有可用的chromedriver")
             exit(1)

--- a/ElectronJS/update_chrome.py
+++ b/ElectronJS/update_chrome.py
@@ -99,8 +99,8 @@ old_driver_version = {
 }
 
 if __name__ == "__main__":
-    #os.system("npm install -g extract-stealth-evasions") # 安装stealth.min.js
-    #os.system("npx extract-stealth-evasions") # 提取stealth.min.js
+    os.system("npm install -g extract-stealth-evasions") # 安装stealth.min.js
+    os.system("npx extract-stealth-evasions") # 提取stealth.min.js
 
     # chromedriver 在 chrome 114 版本之后，提供了一个新的 API 来获取已知的 Chrome 版本和下载链接
     # 之前的版本需要手动维护下载链接

--- a/ExecuteStage/generateExecutable_Macos.sh
+++ b/ExecuteStage/generateExecutable_Macos.sh
@@ -12,6 +12,11 @@ echo "With ddddocr and pandas"
 # # 打包带ddddocr和pandas的版本
 rm -r build
 rm -r dist
-pyinstaller -F --icon=favicon.ico  --add-data "/Users/naibo/anaconda3/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.so:onnxruntime/capi"  --add-data "/Users/naibo/anaconda3/lib/python3.11/site-packages/ddddocr/common_old.onnx:ddddocr" easyspider_executestage.py
+# Get the site-packages path for ddddocr and onnxruntime
+# 如果当前终端激活了 conda 环境，下方脚本应当可以正确的从 conda 环境安装的包中获得数据文件位置
+ddddocr_path=$(python3 -c "import ddddocr; print(ddddocr.__path__[0])")
+onnxruntime_path=$(python3 -c "import onnxruntime; print(onnxruntime.__path__[0])")
+
+pyinstaller -F --icon=favicon.ico --add-data "$onnxruntime_path/capi/onnxruntime_pybind11_state.so:onnxruntime/capi" --add-data "$ddddocr_path/common_old.onnx:ddddocr" easyspider_executestage.py
 rm ../.temp_to_pub/EasySpider_MacOS/easyspider_executestage_full
 cp dist/easyspider_executestage ../.temp_to_pub/EasySpider_MacOS/easyspider_executestage_full


### PR DESCRIPTION
1. 添加了 update_chrome.py 中通过读取 Chrome 应用内部符号链接，自动获取 Chrome 版本号（为了下载对应版本的 Webdriver）的功能
2. 修改 full 版本下打包执行阶段程序采用的数据路径为解释器给出的相对路径（而不是之前带用户名的绝对路径）
3. 修改了 macOS 下内嵌 Chrome 应用的权限为 755（可读可写），从而解决多次打包时无法删除之前打包的 app 的问题
4. 在打包 Electron 程序后添加 adhoc 签名，这样运行程序时就不会提示“程序已损坏”了（改为提示“无法验证开发者“）。这样，就可以从设置-隐私与安全性中选择”仍要打开“直接打开程序，不必须通过 `xattr -d` 命令删除属性才能运行。