### PR TITLE
Fix the binary file not found bug when using Docker

### DIFF
--- a/ExecuteStage/easyspider_executestage.py
+++ b/ExecuteStage/easyspider_executestage.py
@@ -2416,6 +2416,8 @@ if __name__ == '__main__':
                     # Headless mode
                     # options.add_argument("--headless")
                     # print("Headless mode")
+                    options.binary_location = ""
+                    options.extensions.clear()
                     browser_t = MyChrome(command_executor=c.docker_driver, options=options, mode='remote_driver')
             elif browser == "edge":
                 from selenium.webdriver.edge.service import Service as EdgeService


### PR DESCRIPTION
how to reproduce:
docker run -d -p 4444:4444 -p 5900:5900 ...
pip3 install -r requirements.txt
python3 easyspider_executestage.py --ids [0] --docker_driver http://localhost:4444/wd/hub ...

error info:
Message: unknown error: no chrome binary at ..\u002fElectronJS\u002fchrome_win64\u002fchrome.exe