### PR TITLE
fix(server): validate task/instance IDs to prevent path traversal (CWE-22)

### DIFF
--- a/ElectronJS/server.js
+++ b/ElectronJS/server.js
@@ -190,6 +190,20 @@ function generateUuid() {
 
 // When error occurs in the handler, it will be caught and logged, and a 500 response will be sent if headers have not been sent yet.
 // This is useful to prevent the server from crashing due to unhandled exceptions in the request handlers
+
+// SECURITY (CWE-22): Task and execution-instance identifiers are used as file
+// names under tasks/ and execution_instances/. Any non-integer value (e.g.
+// "../../etc/passwd") would let a caller read or write JSON outside those
+// directories. Enforce a strict non-negative integer id everywhere before it
+// is interpolated into a filesystem path.
+function isSafeId(value) {
+  if (value === undefined || value === null) return false;
+  const s = String(value);
+  if (!/^\d+$/.test(s)) return false;
+  const n = Number(s);
+  return Number.isSafeInteger(n) && n >= 0;
+}
+
 function safeHandler(handler, res) {
   return (...args) => {
     try {
@@ -445,6 +459,10 @@ exports.start = function (port = 8074) {
           body = querystring.parse(body);
           data = JSON.parse(body.params);
           let id = data["id"];
+          if (id !== -1 && id !== "-1" && !isSafeId(id)) {
+            writeError(res, 400, "Invalid task ID.");
+            return;
+          }
           if (data["id"] == -1) {
             file_names = [];
             fs.readdirSync(path.join(getDir(), "tasks")).forEach((file) => {
@@ -519,6 +537,10 @@ exports.start = function (port = 8074) {
             writeError(res, 400, "Task ID is required.");
             return;
           }
+          if (!isSafeId(id)) {
+            writeError(res, 400, "Invalid task ID.");
+            return;
+          }
           let task = fs.readFileSync(
             path.join(getDir(), `tasks/${id}.json`),
             "utf8"
@@ -572,6 +594,10 @@ exports.start = function (port = 8074) {
           }
           if (body["EID"] != "" && body["EID"] != undefined) {
             //覆盖原有的执行实例
+            if (!isSafeId(body["EID"])) {
+              writeError(res, 400, "Invalid EID.");
+              return;
+            }
             eid = parseInt(body["EID"]);
           }
           task["id"] = eid;
@@ -878,6 +904,10 @@ exports.start = function (port = 8074) {
             return;
           }
           let id = params.id;
+          if (!isSafeId(id)) {
+            writeError(res, 400, "Invalid execution instance ID.");
+            return;
+          }
           const process_info = child_processes[id];
           if (process_info && process_info.ipc_port) {
             // 进程正在运行，直接读取日志


### PR DESCRIPTION
## Summary

The local HTTP server in `ElectronJS/server.js` uses caller-supplied task and execution-instance IDs directly in filesystem paths without validating that they are integers. Several handlers interpolate `id` into `tasks/${id}.json` or `execution_instances/${id}.json` and hand the result to `fs.readFile` / `fs.writeFile`. A value like `../../evil` escapes the intended directory.

- **CWE**: CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **File**: `ElectronJS/server.js`
- **Affected endpoints**:
  - `/manageTask` — `id` from JSON body is concatenated into `tasks/${id}.json` for `fs.writeFile` (arbitrary JSON write primitive).
  - `/invokeTask` — `EID` from JSON body is concatenated into `execution_instances/${eid}.json` for `fs.writeFile`.
  - `/queryTask`, `/queryExecutionInstance` — `id` from query params flows to `fs.readFile`. These call `parseInt()` later so a pure traversal payload typically yields `NaN.json`, but they still lack strict validation and are trivially hardened by the same helper.

## Why this is reachable

The server binds `127.0.0.1:8074`. CORS is restricted to local origins, but **CORS only blocks the response from being read cross-origin — it does not block the request from being sent**. A cross-origin `fetch()` or auto-submitting `<form>` with `Content-Type: application/x-www-form-urlencoded` is a CORS "simple request" and reaches the local server without a preflight. That means any website the victim visits while EasySpider is running can trigger `/manageTask` or `/invokeTask` and cause a JSON file to be written to an attacker-chosen path (limited to what the desktop process can write, but that includes the user's home directory).

## Fix

Introduce a small `isSafeId()` helper that accepts only non-negative decimal integers within `Number.isSafeInteger` range, and call it before any `id` value is interpolated into a filesystem path in the affected handlers. `/queryTasks` continues to accept the special sentinel value `-1` (meaning "list all"), which is explicitly allowed alongside the strict check.

The change is intentionally minimal (one helper + four call-site checks) and additive — no existing behavior for well-formed integer IDs changes. Invalid IDs now return `400 Invalid ID.` instead of touching the filesystem.

```javascript
function isSafeId(value) {
  if (value === undefined || value === null) return false;
  const s = String(value);
  if (!/^\d+$/.test(s)) return false;
  const n = Number(s);
  return Number.isSafeInteger(n) && n >= 0;
}
```

## Proof of Concept

With EasySpider running (server on `127.0.0.1:8074`), an attacker page can serve:

```html
<script>
fetch("http://127.0.0.1:8074/manageTask", {
  method: "POST",
  mode: "no-cors",
  headers: {"Content-Type": "application/x-www-form-urlencoded"},
  body: "params=" + encodeURIComponent(JSON.stringify({
    id: "../../../../../../tmp/pwned",
    name: "x", url: "", links: [], containers: [], outputParameters: []
  }))
});
</script>
```

Before the patch this results in a JSON file being written at `/tmp/pwned.json` (or the Windows equivalent). After the patch the request is rejected with HTTP 400 and no filesystem write occurs. `curl` equivalent for direct testing:

```bash
curl -X POST http://127.0.0.1:8074/manageTask \
  -d 'params={"id":"../../../../tmp/pwned","name":"x","url":"","links":[],"containers":[],"outputParameters":[]}'
```

## Testing

- Verified the modified handlers (`/queryTasks`, `/queryTask`, `/manageTask`, `/invokeTask`, `/queryExecutionInstance`) still accept normal numeric IDs.
- Confirmed `id=-1` sentinel still works for `/queryTasks` list mode.
- Confirmed non-integer and traversal payloads (`"../x"`, `"1.5"`, `"1e10"`, empty string, negative numbers) now short-circuit with `400`.
- Diff is 30 lines in a single file; no dependency changes, no API-shape changes.

## Adversarial review

Before submitting we tried to disprove this. The two most plausible mitigations are (a) the `parseInt()` calls that appear later in some handlers and (b) the localhost bind + CORS allowlist. Neither is sufficient: `/manageTask` and `/invokeTask` use the raw `id`/`EID` string in the path *before* any `parseInt`, and CORS only gates response reads, not the write-side effect of a simple cross-origin POST from any page the desktop user visits. The branch name references `queryTask`, which is the least severe of the affected endpoints; the substantive risk (and the reason this is worth patching) is the write primitive on `/manageTask` and `/invokeTask`, which the same helper covers.