### PR TITLE
feat: add Xquik X search action

### DIFF
--- a/ElectronJS/src/taskGrid/FlowChart.html
+++ b/ElectronJS/src/taskGrid/FlowChart.html
@@ -389,7 +389,7 @@
                 </div>
 
                 <div class="elements" v-if="nodeType==5">
-                    <p><input spellcheck=false onkeydown="inputDelete(event)" type="checkbox" v-model='nowNode["parameters"]["iframe"]'></input>Action is inside iframe</p>
+                    <p v-if='nowNode["parameters"]["codeMode"] != 13'><input spellcheck=false onkeydown="inputDelete(event)" type="checkbox" v-model='nowNode["parameters"]["iframe"]'></input>Action is inside iframe</p>
                     <label>Action Mode</label>
                     <select v-model='codeMode' class="form-control" @change="handleCodeModeChange">
                         <option :value = 0>Execute JavaScript script (Start with "return " if you want to get return value)</option>
@@ -399,6 +399,7 @@
                         <option v-if="nowNode['isInLoop']" :value = 4>Skip Current Loop (the "Continue" operation)</option>
                         <option :value = 5>Run Python code on current environment (the "exec" operation)</option>
                         <option :value = 6>Get value of a Python expression (the "eval" operation)</option>
+                        <option :value = 13>Search X posts with Xquik</option>
                         <option :value = 7>Pause program execution (such as when the captcha box appears)</option>
                         <option :value = 12>Exit Program</option>
                         <option :value = 8>Refresh page</option>
@@ -406,6 +407,24 @@
                         <option :value = 10>Clear all field values</option>
                         <option :value = 11>Generate new data row</option>
                     </select>
+                    <div v-if='nowNode["parameters"]["codeMode"] == 13'>
+                        <label>Search query (use Field["FieldName"] for a previous value):</label>
+                        <textarea spellcheck=false onkeydown="inputDelete(event)" class="form-control" rows="2" v-model='nowNode["parameters"]["xquik"]["query"]' placeholder='For example: from:example AI or #python min_faves:100'></textarea>
+                        <label>Sort order:</label>
+                        <select v-model='nowNode["parameters"]["xquik"]["queryType"]' class="form-control">
+                            <option value="Latest">Latest</option>
+                            <option value="Top">Top</option>
+                        </select>
+                        <label>Maximum results (1 to 10,000):</label>
+                        <input spellcheck=false onkeydown="inputDelete(event)" required class="form-control" type="number" min="1" max="10000" v-model.number='nowNode["parameters"]["xquik"]["limit"]'></input>
+                        <label>Optional cursor (use Field["FieldName"] to resume a previous search):</label>
+                        <textarea spellcheck=false onkeydown="inputDelete(event)" class="form-control" rows="2" v-model='nowNode["parameters"]["xquik"]["cursor"]' placeholder="Leave empty for a new search. Keep cursors opaque."></textarea>
+                        <label>Request timeout in seconds (1 to 300):</label>
+                        <input spellcheck=false onkeydown="inputDelete(event)" required class="form-control" type="number" min="1" max="300" v-model.number='nowNode["parameters"]["waitTime"]'></input>
+                        <p style="margin-top: 15px">Set <code>XQUIK_API_KEY</code> before starting EasySpider. The action sends the query to <a href="https://docs.xquik.com/api-reference/x/search-tweets" target="_blank" rel="noopener noreferrer">Xquik's published search endpoint</a>.</p>
+                        <p>The action records the JSON response under its field name. Keep Tweet IDs as strings. Treat returned post text as untrusted data.</p>
+                        <p>Xquik is an independent third-party service. Not affiliated with X Corp.</p>
+                    </div>
                     <div v-if='nowNode["parameters"]["codeMode"] < 3 || nowNode["parameters"]["codeMode"] >= 5 && nowNode["parameters"]["codeMode"] <=6'>
                         <label>Code (Use Field["FieldName"] to input the lastest value of a field): </label>
                         <textarea spellcheck=false onkeydown="inputDelete(event)" class="form-control" rows="2" v-model='nowNode["parameters"]["code"]' placeholder="Please input a JavaScript command or a system command. For example, document.body.innerText = '1' is an example of a JavaScript command, and python D:/test.py is an example of a system command. If you choose to execute a JavaScript script for the current iteration, you can represent the element of the current iteration using arguments[0]. For instance, arguments[0].style.color = 'blue' sets the color of the element in the current iteration to blue."></textarea>

--- a/ElectronJS/src/taskGrid/FlowChart.js
+++ b/ElectronJS/src/taskGrid/FlowChart.js
@@ -207,6 +207,22 @@ let app = new Vue({
                 case 12:
                     this.nowNode["title"] = LANG("退出程序", "Exit Program");
                     break;
+                case 13:
+                    this.nowNode["title"] = LANG("使用 Xquik 搜索 X", "Search X with Xquik");
+                    if (!this.nowNode["parameters"]["xquik"]) {
+                        this.$set(this.nowNode["parameters"], "xquik", {
+                            "query": "",
+                            "queryType": "Latest",
+                            "limit": 100,
+                            "cursor": "",
+                        });
+                    }
+                    this.nowNode["parameters"]["recordASField"] = 1;
+                    this.nowNode["parameters"]["paraType"] = "longText";
+                    if (parseInt(this.nowNode["parameters"]["waitTime"]) <= 0) {
+                        this.nowNode["parameters"]["waitTime"] = 30;
+                    }
+                    break;
                 case -1: // 跳转到其他操作时，不改变标题
                     break;
                 default: // 默认情况

--- a/ElectronJS/src/taskGrid/FlowChart_CN.html
+++ b/ElectronJS/src/taskGrid/FlowChart_CN.html
@@ -389,7 +389,7 @@
                 </div>
 
                 <div class="elements" v-if="nodeType==5">
-                    <p><input spellcheck=false onkeydown="inputDelete(event)" type="checkbox" v-model='nowNode["parameters"]["iframe"]'></input>操作在iframe内</p>
+                    <p v-if='nowNode["parameters"]["codeMode"] != 13'><input spellcheck=false onkeydown="inputDelete(event)" type="checkbox" v-model='nowNode["parameters"]["iframe"]'></input>操作在iframe内</p>
                     <label>执行模式</label>
                     <select v-model='codeMode' class="form-control" @change="handleCodeModeChange">
                         <option :value = 0>执行一段JavaScript脚本（如要获得返回值则需以return 开头）</option>
@@ -399,6 +399,7 @@
                         <option v-if="nowNode['isInLoop']" :value = 4>跳过当前循环后面的操作（Continue操作）</option>
                         <option :value = 5>在执行环境下运行Python代码（exec操作）</option>
                         <option :value = 6>在执行环境下获得Python表达式值（eval操作）</option>
+                        <option :value = 13>使用 Xquik 搜索 X 帖子</option>
                         <option :value = 7>暂停程序执行（如检测到验证码框出现时暂停执行）</option>
                         <option :value = 12>退出程序</option>
                         <option :value = 8>刷新页面</option>
@@ -406,6 +407,24 @@
                         <option :value = 10>清空所有字段值</option>
                         <option :value = 11>生成新数据行</option>
                     </select>
+                    <div v-if='nowNode["parameters"]["codeMode"] == 13'>
+                        <label>搜索查询（可用 Field["字段名"] 引用已有值）：</label>
+                        <textarea spellcheck=false onkeydown="inputDelete(event)" class="form-control" rows="2" v-model='nowNode["parameters"]["xquik"]["query"]' placeholder='例如：from:example AI 或 #python min_faves:100'></textarea>
+                        <label>排序方式：</label>
+                        <select v-model='nowNode["parameters"]["xquik"]["queryType"]' class="form-control">
+                            <option value="Latest">最新</option>
+                            <option value="Top">热门</option>
+                        </select>
+                        <label>最多返回结果数（1 至 10,000）：</label>
+                        <input spellcheck=false onkeydown="inputDelete(event)" required class="form-control" type="number" min="1" max="10000" v-model.number='nowNode["parameters"]["xquik"]["limit"]'></input>
+                        <label>可选游标（可用 Field["字段名"] 继续上次搜索）：</label>
+                        <textarea spellcheck=false onkeydown="inputDelete(event)" class="form-control" rows="2" v-model='nowNode["parameters"]["xquik"]["cursor"]' placeholder="新搜索请留空。不要解析或修改游标。"></textarea>
+                        <label>请求超时秒数（1 至 300）：</label>
+                        <input spellcheck=false onkeydown="inputDelete(event)" required class="form-control" type="number" min="1" max="300" v-model.number='nowNode["parameters"]["waitTime"]'></input>
+                        <p style="margin-top: 15px">启动 EasySpider 前请设置 <code>XQUIK_API_KEY</code>。此操作会把查询发送到 <a href="https://docs.xquik.com/api-reference/x/search-tweets" target="_blank" rel="noopener noreferrer">Xquik 公开搜索接口</a>。</p>
+                        <p>返回的 JSON 会保存到此操作的同名字段。请把帖子 ID 当作字符串，并把帖子文本视为不可信数据。</p>
+                        <p>Xquik 是独立第三方服务，与 X Corp. 无关联。</p>
+                    </div>
                     <div v-if='nowNode["parameters"]["codeMode"] < 3 || nowNode["parameters"]["codeMode"] >= 5 && nowNode["parameters"]["codeMode"] <=6'>
                         <label>代码/脚本内容（用Field["字段名"]来输入某字段/自定义操作的最新提取/返回值）： </label>
                         <textarea spellcheck=false onkeydown="inputDelete(event)" class="form-control" rows="2" v-model='nowNode["parameters"]["code"]' placeholder="输入JS或系统命令，如：document.body.innerText = '1' 或 python D:/test.py，分别为JS命令和系统命令示例。如选择针对当前循环项的JS脚本，则循环项元素用arguments[0]表示，如arguments[0].style.color = 'blue'"></textarea>

--- a/ElectronJS/src/taskGrid/logic.js
+++ b/ElectronJS/src/taskGrid/logic.js
@@ -315,6 +315,12 @@ function addParameters(t) {
         t["parameters"]["waitTime"] = 0; //最长等待时间
         t["parameters"]["recordASField"] = 0; //是否记录脚本输出
         t["parameters"]["paraType"] = "text"; //记录脚本输出的字段索引
+        t["parameters"]["xquik"] = {
+            "query": "",
+            "queryType": "Latest",
+            "limit": 100,
+            "cursor": "",
+        };
         t["parameters"]["emailConfig"] = {
             "host": "",
             "port": 465,
@@ -708,5 +714,4 @@ if (sId != null && sId != -1) //加载任务
 } else {
     refresh(); //新增任务
 }
-
 

--- a/ExecuteStage/easyspider_executestage.py
+++ b/ExecuteStage/easyspider_executestage.py
@@ -11,6 +11,7 @@ from utils import detect_optimizable, download_image, extract_text_from_html, ge
     on_press_creator, on_release_creator, readCode, rename_downloaded_file, replace_field_values, send_email, split_text_by_lines, write_to_csv, write_to_excel, write_to_json
 from constants import WriteMode, DataWriteMode, GraphOption
 from myChrome import MyChrome
+from xquik import XquikSearchError, search_tweets as search_xquik_tweets
 from threading import Thread, Event
 from PIL import Image
 from commandline_config import Config
@@ -300,6 +301,19 @@ class BrowserThread(Thread):
             elif option == GraphOption.Custom.value:  # 自定义操作
                 parameters['clear'] = parameters.get('clear', 0)
                 parameters['newLine'] = parameters.get('newLine', 1)
+                parameters['code'] = parameters.get('code', '')
+                parameters['recordASField'] = parameters.get('recordASField', 0)
+                parameters['paraType'] = parameters.get('paraType', 'text')
+                parameters['waitTime'] = parameters.get('waitTime', 0)
+                xquik = parameters.get('xquik')
+                if not isinstance(xquik, dict):
+                    xquik = {}
+                parameters['xquik'] = {
+                    'query': xquik.get('query', ''),
+                    'queryType': xquik.get('queryType', 'Latest'),
+                    'limit': xquik.get('limit', 100),
+                    'cursor': xquik.get('cursor', ''),
+                }
             elif option == GraphOption.Move.value:  # 移动到元素
                 if parameters.get('useLoop'):
                     if self.task_version <= "0.3.5":  # 0.3.5及以下版本的EasySpider下的循环点击不支持相对XPath
@@ -838,6 +852,28 @@ class BrowserThread(Thread):
                 pass
             self.print_and_log("清理完成！|Clean up completed!")
             os._exit(0)
+        elif codeMode == 13: # 使用 Xquik 搜索 X
+            xquik = params["xquik"]
+            query = replace_field_values(
+                str(xquik["query"]), self.outputParameters, self
+            )
+            cursor = replace_field_values(
+                str(xquik["cursor"]), self.outputParameters, self
+            )
+            timeout = max_wait_time if max_wait_time > 0 else 30
+            try:
+                payload = search_xquik_tweets(
+                    query=query,
+                    query_type=xquik["queryType"],
+                    limit=xquik["limit"],
+                    cursor=cursor,
+                    timeout=timeout,
+                )
+                output = json.dumps(payload, ensure_ascii=False)
+            except (ValueError, XquikSearchError) as error:
+                self.print_and_log(
+                    "Xquik 搜索失败：|Xquik search failed:", str(error)
+                )
         else:  # 0 1 5 6
             output = self.execute_code(
                 codeMode, code, max_wait_time, iframe=params["iframe"])

--- a/ExecuteStage/xquik.py
+++ b/ExecuteStage/xquik.py
@@ -1,0 +1,97 @@
+import os
+
+import requests
+
+
+SEARCH_URL = "https://xquik.com/api/v1/x/tweets/search"
+MAX_RESULTS = 10000
+MAX_TIMEOUT_SECONDS = 300
+
+
+class XquikSearchError(RuntimeError):
+    """Raised when a Xquik search cannot return a usable response."""
+
+
+def _require_integer(value, name, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
+def search_tweets(
+    query,
+    query_type="Latest",
+    limit=100,
+    cursor="",
+    timeout=30,
+    api_key=None,
+    request_get=None,
+):
+    query = str(query).strip()
+    if not query:
+        raise ValueError("query is required")
+    if not isinstance(query_type, str) or query_type not in {"Latest", "Top"}:
+        raise ValueError("query_type must be Latest or Top")
+
+    limit = _require_integer(limit, "limit", 1, MAX_RESULTS)
+    timeout = _require_integer(timeout, "timeout", 1, MAX_TIMEOUT_SECONDS)
+    api_key = api_key or os.environ.get("XQUIK_API_KEY", "")
+    if not isinstance(api_key, str):
+        raise ValueError("api_key must be text")
+    api_key = api_key.strip()
+    if not api_key:
+        raise XquikSearchError("Set XQUIK_API_KEY before starting EasySpider")
+
+    params = {"q": query, "queryType": query_type, "limit": limit}
+    cursor = str(cursor).strip()
+    if cursor:
+        params["cursor"] = cursor
+
+    if request_get is None:
+        request_get = requests.get
+    try:
+        response = request_get(
+            SEARCH_URL,
+            headers={"Accept": "application/json", "x-api-key": api_key},
+            params=params,
+            timeout=timeout,
+        )
+    except requests.RequestException as error:
+        raise XquikSearchError(
+            "Could not reach Xquik. Check the network and retry"
+        ) from error
+
+    status = response.status_code
+    if status == 401:
+        raise XquikSearchError("Xquik authentication failed. Check XQUIK_API_KEY")
+    if status == 402:
+        raise XquikSearchError(
+            "Xquik credits are unavailable. Check the Xquik dashboard"
+        )
+    if status == 429:
+        raise XquikSearchError("Xquik rate limit reached. Retry later")
+    if status < 200 or status >= 300:
+        raise XquikSearchError(f"Xquik request failed with HTTP {status}")
+
+    try:
+        payload = response.json()
+    except ValueError as error:
+        raise XquikSearchError("Xquik returned invalid JSON") from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("tweets"), list):
+        raise XquikSearchError("Xquik returned an invalid tweet-search response")
+    for tweet in payload["tweets"]:
+        if not isinstance(tweet, dict):
+            raise XquikSearchError("Xquik returned an invalid tweet-search response")
+        if "id" in tweet and not isinstance(tweet["id"], str):
+            raise XquikSearchError("Xquik returned a non-string Tweet ID")
+    if "has_next_page" in payload and not isinstance(payload["has_next_page"], bool):
+        raise XquikSearchError("Xquik returned invalid pagination metadata")
+    if (
+        "next_cursor" in payload
+        and payload["next_cursor"] is not None
+        and not isinstance(payload["next_cursor"], str)
+    ):
+        raise XquikSearchError("Xquik returned invalid pagination metadata")
+    return payload

--- a/Readme.md
+++ b/Readme.md
@@ -164,6 +164,38 @@ Refer to [Youtube Playlist](https://youtube.com/playlist?list=PL0kEFEkWrT7mt9MUl
 
 Download sample tasks from the [Examples](Examples) folder of this project, rename them to numbers greater than 0, import them into the `tasks` folder in EasySpider, and then open them in EasySpider.
 
+## 使用 Xquik 搜索 X 帖子 / Search X Posts with Xquik
+
+EasySpider 的自定义操作支持 Xquik 帖子搜索。此操作使用 API 获取限定数量的结果，不需要滚动网页。
+
+EasySpider includes a Xquik search action. It fetches a bounded result set through the API without scrolling a web page.
+
+启动 EasySpider 前设置 API 密钥：
+
+Set the API key before starting EasySpider:
+
+```bash
+export XQUIK_API_KEY="your-api-key"
+```
+
+Start EasySpider from the same terminal session.
+
+Windows PowerShell:
+
+```powershell
+$env:XQUIK_API_KEY = "your-api-key"
+```
+
+从同一个终端会话启动 EasySpider。
+
+在任务设计器中添加“自定义操作”，然后选择“使用 Xquik 搜索 X 帖子”。填写查询、排序方式和结果上限。需要继续搜索时，可传入上次响应的游标。返回的 JSON 会保存到操作的同名字段。
+
+Add a **Custom Action**, then select **Search X posts with Xquik**. Set the query, sort order, and result limit. Pass the previous response cursor to resume a search. EasySpider stores the JSON response under the action's field name.
+
+See the [Xquik tweet-search API](https://docs.xquik.com/api-reference/x/search-tweets) for query operators and response fields. Keep API keys outside task files. Keep Tweet IDs as strings.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
 ## 声明/Declaration
 
 本软件仅供学习交流使用，**严禁使用软件进行任何违法违规的操作，如爬取不允许爬取的政府/军事机关网站等**。使用本软件所造成的**一切后果由使用者自负**，与作者本人无关，**作者不会承担任何责任**。

--- a/scripts/test_xquik_search.py
+++ b/scripts/test_xquik_search.py
@@ -1,0 +1,184 @@
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import requests
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ExecuteStage"))
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+from xquik import SEARCH_URL, XquikSearchError, search_tweets
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, json_error=None):
+        self.status_code = status_code
+        self.payload = payload
+        self.json_error = json_error
+
+    def json(self):
+        if self.json_error is not None:
+            raise self.json_error
+        return self.payload
+
+
+class XquikSearchTests(unittest.TestCase):
+    def test_search_sends_bounded_request_and_returns_payload(self):
+        calls = []
+        payload = {
+            "tweets": [{"id": "1893704267862470862", "text": "Hello"}],
+            "has_next_page": True,
+            "next_cursor": "opaque-cursor",
+        }
+
+        def fake_get(url, **kwargs):
+            calls.append((url, kwargs))
+            return FakeResponse(payload=payload)
+
+        result = search_tweets(
+            "from:example",
+            query_type="Top",
+            limit=250,
+            cursor=" next-page ",
+            timeout=45,
+            api_key="secret-key",
+            request_get=fake_get,
+        )
+
+        self.assertEqual(result, payload)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], SEARCH_URL)
+        self.assertEqual(
+            calls[0][1]["params"],
+            {
+                "q": "from:example",
+                "queryType": "Top",
+                "limit": 250,
+                "cursor": "next-page",
+            },
+        )
+        self.assertEqual(calls[0][1]["timeout"], 45)
+        self.assertEqual(calls[0][1]["headers"]["x-api-key"], "secret-key")
+        self.assertNotIn("secret-key", json.dumps(result))
+
+    def test_search_reads_api_key_from_environment(self):
+        captured = []
+
+        def fake_get(_url, **kwargs):
+            captured.append(kwargs)
+            return FakeResponse(payload={"tweets": []})
+
+        with patch.dict(os.environ, {"XQUIK_API_KEY": "environment-key"}, clear=True):
+            search_tweets("EasySpider", request_get=fake_get)
+
+        self.assertEqual(captured[0]["headers"]["x-api-key"], "environment-key")
+        self.assertNotIn("cursor", captured[0]["params"])
+
+    def test_search_rejects_invalid_inputs_before_request(self):
+        cases = [
+            {"query": ""},
+            {"query": "test", "query_type": "Recent"},
+            {"query": "test", "query_type": []},
+            {"query": "test", "limit": True},
+            {"query": "test", "limit": 0},
+            {"query": "test", "limit": 10001},
+            {"query": "test", "timeout": 0},
+            {"query": "test", "timeout": 301},
+        ]
+
+        for values in cases:
+            with self.subTest(values=values):
+                with self.assertRaises(ValueError):
+                    search_tweets(api_key="key", **values)
+
+    def test_search_requires_environment_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(XquikSearchError, "XQUIK_API_KEY"):
+                search_tweets("test")
+
+    def test_search_maps_safe_http_errors(self):
+        expected = {
+            401: "authentication failed",
+            402: "credits are unavailable",
+            429: "rate limit reached",
+            503: "HTTP 503",
+        }
+
+        for status, message in expected.items():
+            with self.subTest(status=status):
+                with self.assertRaisesRegex(XquikSearchError, message):
+                    search_tweets(
+                        "test",
+                        api_key="secret-key",
+                        request_get=lambda *_args, **_kwargs: FakeResponse(
+                            status_code=status,
+                            payload={"private": "response body"},
+                        ),
+                    )
+
+    def test_search_maps_connection_errors_without_secret(self):
+        def fail_request(*_args, **_kwargs):
+            raise requests.ConnectionError("request failed with secret-key")
+
+        with self.assertRaises(XquikSearchError) as context:
+            search_tweets(
+                "test", api_key="secret-key", request_get=fail_request
+            )
+
+        self.assertNotIn("secret-key", str(context.exception))
+
+    def test_search_rejects_invalid_json_and_response_shape(self):
+        responses = [
+            FakeResponse(json_error=ValueError("bad json")),
+            FakeResponse(payload=[]),
+            FakeResponse(payload={"tweets": {}}),
+            FakeResponse(payload={"tweets": [{"id": 1893704267862470862}]}),
+            FakeResponse(payload={"tweets": [], "has_next_page": "yes"}),
+            FakeResponse(payload={"tweets": [], "next_cursor": 12}),
+        ]
+
+        for response in responses:
+            with self.subTest(response=response.payload):
+                with self.assertRaises(XquikSearchError):
+                    search_tweets(
+                        "test",
+                        api_key="key",
+                        request_get=lambda *_args, **_kwargs: response,
+                    )
+
+
+class XquikIntegrationFilesTests(unittest.TestCase):
+    def test_action_is_wired_into_both_editors_and_runtime(self):
+        english = (
+            REPOSITORY_ROOT / "ElectronJS/src/taskGrid/FlowChart.html"
+        ).read_text(encoding="utf-8")
+        chinese = (
+            REPOSITORY_ROOT / "ElectronJS/src/taskGrid/FlowChart_CN.html"
+        ).read_text(encoding="utf-8")
+        logic = (
+            REPOSITORY_ROOT / "ElectronJS/src/taskGrid/FlowChart.js"
+        ).read_text(encoding="utf-8")
+        executor = (
+            REPOSITORY_ROOT / "ExecuteStage/easyspider_executestage.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            '<option :value = 13>Search X posts with Xquik</option>', english
+        )
+        self.assertIn(
+            '<option :value = 13>使用 Xquik 搜索 X 帖子</option>', chinese
+        )
+        self.assertIn("case 13:", logic)
+        self.assertIn("elif codeMode == 13:", executor)
+        self.assertNotIn(
+            'v-model=\'nowNode["parameters"]["xquik"]["apiKey"]\'', english
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Issue #548 reports partial Twitter search collection after long browser scrolls. EasySpider supports manual Python calls, but that leaves a code-only workaround in a no-code product.

## Change

- Add a maintained Search X posts with Xquik custom action.
- Accept advanced queries, Latest or Top sorting, bounded results, and opaque cursors.
- Read XQUIK_API_KEY only from the process environment.
- Store the JSON response as a long-text task field.
- Validate result bounds, pagination metadata, and string Tweet IDs.
- Return safe errors without logging credentials or response bodies.
- Add matching English and Chinese controls and setup documentation.

The runtime calls the published GET /api/v1/x/tweets/search contract directly through the existing requests dependency. It adds no package dependency and contains no private Xquik code.

Addresses #548.

## Validation

- python3 scripts/test_xquik_search.py: 8 tests passed
- python3 -m py_compile ExecuteStage/xquik.py ExecuteStage/easyspider_executestage.py scripts/test_xquik_search.py
- node --check ElectronJS/src/taskGrid/FlowChart.js
- node --check ElectronJS/src/taskGrid/logic.js
- git diff --check

The client tests cover request construction, environment authentication, bounds, safe HTTP and network errors, response validation, string IDs, pagination metadata, and both editor variants.